### PR TITLE
Refactor Splitter to use string_view

### DIFF
--- a/data/filter.cpp
+++ b/data/filter.cpp
@@ -33,7 +33,7 @@ Filter::Filter(const std::string &file_path) {
     }
     RJBUtil::Splitter<std::string> variant(splitter[0], ":");
     for (int i = 1; i < splitter.size(); i++) {
-      if (strcmp(splitter[i].c_str(), "1") == 0) {
+      if (splitter[i] == "1") {
         method_type_map[methods[i - 1]].insert(variant[1]);
       }
     }


### PR DESCRIPTION
## Summary
- refactor utility/split.hpp to store tokens as `std::string_view` and avoid extra string copies
- allow Splitter to optionally own its input string to keep token views valid
- adjust filter to compare `Splitter` tokens via string views

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Armadillo (missing: ARMADILLO_INCLUDE_DIR))*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb41ddf348320b4ab7c08af557e1d