### PR TITLE
Ensure matrix header splitting uses owning string

### DIFF
--- a/utility/filevalidator.cpp
+++ b/utility/filevalidator.cpp
@@ -108,7 +108,12 @@ void FileValidator::validate_weight_line(RJBUtil::Splitter<std::string> &line,
 }
 
 void FileValidator::set_matrix_header(const std::string &header) {
-  matrix_header = RJBUtil::Splitter<std::string>(header, "\t");
+  // Pass an owning string to Splitter so that the header fields referenced by
+  // matrix_header remain valid even after the original `header` argument goes
+  // out of scope. Using `std::string(header)` creates an rvalue that invokes
+  // the owning constructor of Splitter.
+  matrix_header =
+      RJBUtil::Splitter<std::string>(std::string(header), "\t");
   matrix_sample_count =
       matrix_header.size() - static_cast<size_t>(Indices::first);
 }


### PR DESCRIPTION
## Summary
- Use an owning `std::string` when constructing `Splitter` in `set_matrix_header` to ensure header tokens remain valid after the call.

## Testing
- `cmake -S . -B build`
- `cmake --build build --target catch_test` *(fails: mach-o/dyld.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68beedd883b88320a3d2194cfb10e64d