### PR TITLE
Ensure JobDispatcher owns gene list data

### DIFF
--- a/utility/split.hpp
+++ b/utility/split.hpp
@@ -44,9 +44,12 @@ public:
   }
 
   Splitter(const string_type &&str, const string_type &delim)
-	  : data_(str), delim_(delim) {
-	split();
+          : data_(str), delim_(delim) {
+        split();
   }
+
+  Splitter(const Splitter &rhs) = default;
+  Splitter(Splitter &&rhs) noexcept = default;
 
   Splitter &operator=(const Splitter &rhs) {
 	data_ = rhs.data_;


### PR DESCRIPTION
## Summary
- Move gene list string into JobDispatcher to prevent TaskParams copies from retaining large gene lists
- Add explicit copy/move constructors to RJBUtil::Splitter

## Testing
- `cmake ..` *(passes)*
- `make -j2` *(fails: struct TaskParams has no member named stage_1_permutations)*

------
https://chatgpt.com/codex/tasks/task_e_68beedf3e9788320b96a34c6097a20a1