### PR TITLE
Add string access to Splitter and update numeric parsing

### DIFF
--- a/caese/caese.cpp
+++ b/caese/caese.cpp
@@ -300,8 +300,8 @@ int main(int argc, char **argv) {
   tp.adjust = adjust;
   tp.linear = linear;
   // Beta weights
-  tp.a = std::stoi(beta_split[0]);
-  tp.b = std::stoi(beta_split[1]);
+  tp.a = std::stoi(beta_split.str(0));
+  tp.b = std::stoi(beta_split.str(1));
   // Testability
   tp.testable = testable;
   tp.biallelic = biallelic;
@@ -316,9 +316,21 @@ int main(int argc, char **argv) {
 
 	std::vector<double> alpha_tmp;
 
-	std::transform(alpha_splitter.begin(), alpha_splitter.end(), std::back_inserter(alpha_tmp), [](std::string &v) { return std::stod(v); });
-	std::transform(ncase_splitter.begin(), ncase_splitter.end(), std::back_inserter(tp.ncases), [](std::string &v) { return std::stoul(v); });
-	std::transform(ncontrol_splitter.begin(), ncontrol_splitter.end(), std::back_inserter(tp.ncontrols), [](std::string &v) { return std::stoul(v); });
+        std::transform(alpha_splitter.begin(), alpha_splitter.end(),
+                       std::back_inserter(alpha_tmp),
+                       [](auto v) {
+                         return std::stod(RJBUtil::Splitter<std::string>::str(v));
+                       });
+        std::transform(ncase_splitter.begin(), ncase_splitter.end(),
+                       std::back_inserter(tp.ncases),
+                       [](auto v) {
+                         return std::stoul(RJBUtil::Splitter<std::string>::str(v));
+                       });
+        std::transform(ncontrol_splitter.begin(), ncontrol_splitter.end(),
+                       std::back_inserter(tp.ncontrols),
+                       [](auto v) {
+                         return std::stoul(RJBUtil::Splitter<std::string>::str(v));
+                       });
 
 	tp.alpha = arma::conv_to<arma::vec>::from(alpha_tmp);
 

--- a/caper/caper.cpp
+++ b/caper/caper.cpp
@@ -410,8 +410,8 @@ int main(int argc, char **argv) {
   tp.saddlepoint = saddlepoint;
   tp.var_collapsing = var_collapsing;
   // Beta weights
-  tp.a = std::stoi(beta_split[0]);
-  tp.b = std::stoi(beta_split[1]);
+    tp.a = std::stoi(beta_split.str(0));
+    tp.b = std::stoi(beta_split.str(1));
   // Testability
   tp.testable = testable;
   tp.biallelic = biallelic;
@@ -499,7 +499,7 @@ int main(int argc, char **argv) {
   if (tp.bed) {
     RJBUtil::Splitter<std::string> bed_paths(*tp.bed, ",");
     for (const auto &f : bed_paths) {
-      if (!check_file_exists(f)) {
+      if (!check_file_exists(std::string(f))) {
         std::cerr << "Incorrect file path for bed_file." << std::endl;
         std::cerr << visible << "\n";
         std::exit(1);

--- a/data/bed.cpp
+++ b/data/bed.cpp
@@ -27,12 +27,13 @@ Bed::Bed(const std::string &ifile) {
   size_t reserve = 1000000;
   variants_.reserve(reserve);
   for (const auto &f : files) {
-    if (!check_file_exists(f)) {
+    auto path = std::string(f);
+    if (!check_file_exists(path)) {
       std::cerr << "No mask file provided or incorrect path to mask file. "
                 << f << std::endl;
       return;
     }
-    std::ifstream ifs(f);
+    std::ifstream ifs(path);
     std::string line;
     int lineno = -1;
 

--- a/data/covariates.cpp
+++ b/data/covariates.cpp
@@ -182,7 +182,7 @@ void Covariates::parse_cov(const std::string &covfile) {
       }
 
       // Retrieve sample identifier from the first field.
-      std::string sampleid = splitter[0];
+      std::string sampleid = splitter.str(0);
       // Ensure that the sample has enough columns; otherwise, mark sample as skipped.
       if (splitter.size() < nfields + 1) {
         skip_.emplace(sampleid);
@@ -216,10 +216,10 @@ void Covariates::parse_cov(const std::string &covfile) {
             std::exit(-1);
           }
           // Convert field to double.
-          data[sampleid][i] = std::stod(splitter[i + 1]);
+          data[sampleid][i] = std::stod(splitter.str(i + 1));
         } catch (...) {
           // Conversion failed; store the value for categorical processing.
-          unconvertible[i].push_back(splitter[i + 1]);
+          unconvertible[i].push_back(splitter.str(i + 1));
         }
       }
       lineno++;
@@ -347,22 +347,22 @@ void Covariates::parse_ped(const std::string &pedfile, bool cov_provided) {
 
     FileValidator::validate_ped_line(splitter, lineno);
 
-    std::string sample_id = splitter[1];
+      std::string sample_id = splitter.str(1);
     ped_samples_.insert(sample_id);
     ped_samples_ordered_.push_back(sample_id);
     nsamples_++;
     if (linear_) {
-      try {
-        sample_phen_map_[sample_id] = std::stod(splitter[5]);
+        try {
+          sample_phen_map_[sample_id] = std::stod(splitter.str(5));
       } catch (std::exception &e) {
         std::cerr << "Failed to convert quantitative phenotype in .ped file "
                      "column 7.\n";
         throw(e);
       }
     } else {
-      try {
-        double phen = std::stoi(splitter[5]);
-        sample_phen_map_[sample_id] = phen - 1;
+        try {
+          double phen = std::stoi(splitter.str(5));
+          sample_phen_map_[sample_id] = phen - 1;
       } catch (std::exception &e) {
         std::cerr
             << "Failed to convert binary phenotype in .ped file column 6.\n";
@@ -405,15 +405,15 @@ void Covariates::parse(const std::string &covfile, const std::string &pedfile) {
     lineno++;
     RJBUtil::Splitter<std::string> splitter(line, " \t");
     FileValidator::validate_cov_line(splitter, lineno);
-    if(this->contains(splitter[0])) {
-      covariates.emplace_back(std::vector<double>());
-      unsigned long i = 0;
-      for (const auto &v : splitter) {
-        if (i == 0) {
-          // Get phenotype of current sample
-          auto phen = sample_phen_map_[v];
+      if(this->contains(splitter[0])) {
+        covariates.emplace_back(std::vector<double>());
+        unsigned long i = 0;
+        for (const auto &v : splitter) {
+          if (i == 0) {
+            // Get phenotype of current sample
+            auto phen = sample_phen_map_[RJBUtil::Splitter<std::string>::str(v)];
 
-          cov_samples_.push_back(v);
+            cov_samples_.push_back(RJBUtil::Splitter<std::string>::str(v));
 
           if (phen == 1) {
             ncases_++;
@@ -422,9 +422,10 @@ void Covariates::parse(const std::string &covfile, const std::string &pedfile) {
           }
 
           phenotypes.push_back(phen);
-        } else {
-          covariates.back().push_back(std::stod(v));
-        }
+          } else {
+            covariates.back().push_back(
+                std::stod(RJBUtil::Splitter<std::string>::str(v)));
+          }
         i++;
       }
     }
@@ -475,22 +476,22 @@ void Covariates::parse(std::stringstream &ped_ss, std::stringstream &cov_ss) {
     }
     RJBUtil::Splitter<std::string> splitter(line, "\t");
 
-    std::string sample_id = splitter[1];
+      std::string sample_id = splitter.str(1);
     ped_samples_.insert(sample_id);
 
     nsamples_++;
     if (linear_) {
-      try {
-        sample_phen_map[sample_id] = std::stod(splitter[5]);
+        try {
+          sample_phen_map[sample_id] = std::stod(splitter.str(5));
       } catch (std::exception &e) {
         std::cerr << "Failed to convert quantitative phenotype in .ped file "
                      "column 7.\n";
         throw(e);
       }
     } else {
-      try {
-        double phen = std::stoi(splitter[5]);
-        sample_phen_map[sample_id] = phen - 1;
+        try {
+          double phen = std::stoi(splitter.str(5));
+          sample_phen_map[sample_id] = phen - 1;
       } catch (std::exception &e) {
         std::cerr
             << "Failed to convert binary phenotype in .ped file column 6.\n";
@@ -502,16 +503,16 @@ void Covariates::parse(std::stringstream &ped_ss, std::stringstream &cov_ss) {
   // Parse the PCA matrix file
   while (std::getline(cov_ss, line, '\n')) {
     RJBUtil::Splitter<std::string> splitter(line, " \t");
-    if (this->contains(splitter[0])) {
-      covariates.emplace_back(std::vector<double>());
+      if (this->contains(splitter[0])) {
+        covariates.emplace_back(std::vector<double>());
 
-      unsigned long i = 0;
-      for (const auto &v : splitter) {
-        if (i == 0) {
-          // Get phenotype of current sample
-          auto phen = sample_phen_map[v];
+        unsigned long i = 0;
+        for (const auto &v : splitter) {
+          if (i == 0) {
+            // Get phenotype of current sample
+            auto phen = sample_phen_map[RJBUtil::Splitter<std::string>::str(v)];
 
-          cov_samples_.push_back(v);
+            cov_samples_.push_back(RJBUtil::Splitter<std::string>::str(v));
 
           if (phen == 1) {
             ncases_++;
@@ -520,9 +521,10 @@ void Covariates::parse(std::stringstream &ped_ss, std::stringstream &cov_ss) {
           }
 
           phenotypes.push_back(phen);
-        } else {
-          covariates.back().push_back(std::stod(v));
-        }
+          } else {
+            covariates.back().push_back(
+                std::stod(RJBUtil::Splitter<std::string>::str(v)));
+          }
         i++;
       }
     }
@@ -641,8 +643,9 @@ void Covariates::sort_covariates(const std::string &header) {
 
     seen.clear();
     for (const auto &v : splitter) {
-      if (!seen.contains(v)) {
-        seen.insert(v);
+      auto token = std::string(v);
+      if (!seen.contains(token)) {
+        seen.insert(std::move(token));
       } else {
         std::cerr << "header duplicate: " << v << std::endl;
       }

--- a/data/filter.cpp
+++ b/data/filter.cpp
@@ -24,8 +24,9 @@ Filter::Filter(const std::string &file_path) {
     lineno++;
     RJBUtil::Splitter<std::string> splitter(line, ",");
     if (lineno == 0) {
-      std::copy(splitter.begin() + 1, splitter.end(),
-                std::back_inserter(methods));
+      for (auto it = splitter.begin() + 1; it != splitter.end(); ++it) {
+        methods.emplace_back(std::string(*it));
+      }
       continue;
     }
     if (boost::starts_with(line, "#")) { // Skip commented lines
@@ -34,7 +35,7 @@ Filter::Filter(const std::string &file_path) {
     RJBUtil::Splitter<std::string> variant(splitter[0], ":");
     for (int i = 1; i < splitter.size(); i++) {
       if (splitter[i] == "1") {
-        method_type_map[methods[i - 1]].insert(variant[1]);
+        method_type_map[methods[i - 1]].insert(std::string(variant[1]));
       }
     }
   }
@@ -42,10 +43,8 @@ Filter::Filter(const std::string &file_path) {
 
 bool Filter::allow_variant(const std::string &method,
                            RJBUtil::Splitter<std::string> &variant) {
-  return method_type_map[method].find(
-             variant[static_cast<int>(Indices::type)]) !=
-             method_type_map[method].end() &&
-         method_type_map[method].find(
-             variant[static_cast<int>(Indices::function)]) !=
-             method_type_map[method].end();
+  auto type = variant.str(static_cast<int>(Indices::type));
+  auto func = variant.str(static_cast<int>(Indices::function));
+  return method_type_map[method].find(type) != method_type_map[method].end() &&
+         method_type_map[method].find(func) != method_type_map[method].end();
 }

--- a/data/weight.cpp
+++ b/data/weight.cpp
@@ -70,7 +70,7 @@ Weight::Weight(const std::string &ifile) {
 
     double weight = 1;
     try {
-      weight = std::stod(splitter.at(weight_index));
+      weight = std::stod(splitter.at_str(weight_index));
     } catch (std::exception &e) {
       std::cerr << "Failed to convert weight to double. Line was: " << line
                 << std::endl;
@@ -159,7 +159,7 @@ Weight::Weight(std::stringstream &ifile) {
     // Parse and store the weight value
     double weight = 1;
     try {
-      weight = std::stod(splitter.at(weight_index));
+      weight = std::stod(splitter.at_str(weight_index));
     } catch (std::exception &e) {
       std::cerr << "Failed to convert weight to double. Line was: " << line
                 << std::endl;

--- a/power/power.cpp
+++ b/power/power.cpp
@@ -336,8 +336,8 @@ int main(int argc, char **argv) {
   tp.kernel = vm["kernel"].as<std::string>();
   tp.qtl = linear;
   // Beta weights
-  tp.a = std::stoi(beta_split[0]);
-  tp.b = std::stoi(beta_split[1]);
+  tp.a = std::stoi(beta_split.str(0));
+  tp.b = std::stoi(beta_split.str(1));
   // Testability
   tp.testable = testable;
   tp.biallelic = biallelic;
@@ -355,13 +355,19 @@ int main(int argc, char **argv) {
 
     std::transform(alpha_splitter.begin(), alpha_splitter.end(),
                    std::back_inserter(alpha_tmp),
-                   [](std::string &v) { return std::stod(v); });
+                   [](auto v) {
+                     return std::stod(RJBUtil::Splitter<std::string>::str(v));
+                   });
     std::transform(ncase_splitter.begin(), ncase_splitter.end(),
                    std::back_inserter(tp.ncases),
-                   [](std::string &v) { return std::stoul(v); });
+                   [](auto v) {
+                     return std::stoul(RJBUtil::Splitter<std::string>::str(v));
+                   });
     std::transform(ncontrol_splitter.begin(), ncontrol_splitter.end(),
                    std::back_inserter(tp.ncontrols),
-                   [](std::string &v) { return std::stoul(v); });
+                   [](auto v) {
+                     return std::stoul(RJBUtil::Splitter<std::string>::str(v));
+                   });
 
     tp.alpha = arma::conv_to<arma::vec>::from(alpha_tmp);
 

--- a/statistics/vaast.cpp
+++ b/statistics/vaast.cpp
@@ -274,8 +274,8 @@ void VAASTLogic::alternate_grouping(const arma::sp_mat &X, const arma::vec &Y,
     std::stringstream loc;
     loc << splitter[0] << "-" << splitter[1] << "-" << splitter[2];
     variants.emplace_back(case_allele1(i), case_allele0(i), control_allele1(i),
-                          control_allele0(i), w(i), splitter[5], loc.str(), i,
-                          soft_maf_filter);
+                          control_allele0(i), w(i), splitter.str(5), loc.str(),
+                          i, soft_maf_filter);
   }
 
   std::vector<std::vector<Variant>> sub_groups;
@@ -396,7 +396,7 @@ void VAASTLogic::vaast_grouping(const arma::sp_mat &X, const arma::vec &Y,
     RJBUtil::Splitter<std::string> splitter(positions[i], ",");
     std::stringstream loc;
     loc << splitter[0] << "-" << splitter[1] << "-" << splitter[2];
-    std::string type = splitter[5];
+    std::string type = splitter.str(5);
     if (type == "SNV") {
       SNVs.emplace_back(Variant(case_allele1(i), case_allele0(i),
                                 control_allele1(i), control_allele0(i), w(i),

--- a/tools/vcf2matrix/parser.cpp
+++ b/tools/vcf2matrix/parser.cpp
@@ -64,9 +64,9 @@ void Parser::parse(std::istream &is, std::ostream &os) { // Parse VCF
 	  os << std::endl;
 	  continue;
 	} // Fallthrough
-	RJBUtil::Splitter<std::string> splitter(line, " \t");
-	chr = splitter[0];
-	long pos = std::stol(splitter[1]);
+        RJBUtil::Splitter<std::string> splitter(line, " \t");
+        chr = splitter.str(0);
+        long pos = std::stol(splitter.str(1));
 
 	if (!boost::starts_with(chr, "chr")) {
 	  chr = "chr" + chr;
@@ -92,7 +92,11 @@ void Parser::parse(std::istream &is, std::ostream &os) { // Parse VCF
 	Variant var{
 		location_stream.str()
 	};
-	std::transform(splitter.begin() + 9, splitter.end(), std::back_inserter(var.data), &Parser::variant_converter);
+        std::transform(splitter.begin() + 9, splitter.end(), std::back_inserter(var.data),
+                       [](auto v) {
+                         return Parser::variant_converter(
+                             RJBUtil::Splitter<std::string>::str(v));
+                       });
 
 	std::vector<std::shared_ptr<Gene>> match = ref_.get_gene(chr, pos);
 	for (const auto &p : match) {

--- a/tools/vcf2matrix/reference.cpp
+++ b/tools/vcf2matrix/reference.cpp
@@ -61,15 +61,18 @@ void Reference::parse_refFlat(std::istream &ifs) {
 		}
 		data_[splitter[static_cast<int>(refFlat::chri)]].back()->chromosome = splitter[static_cast<int>(refFlat::chri)];
 		data_[splitter[static_cast<int>(refFlat::chri)]].back()->strand = splitter[static_cast<int>(refFlat::strandi)];
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->positions[splitter[static_cast<int>(refFlat::txi)]] =
-			std::make_pair(std::stol(splitter[static_cast<int>(refFlat::starti)]), std::stol(splitter[static_cast<int>(refFlat::endi)]));
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->cds[splitter[static_cast<int>(refFlat::txi)]] =
-			std::make_pair(std::stol(splitter[static_cast<int>(refFlat::cds_starti)]), std::stol(splitter[static_cast<int>(refFlat::cds_endi)]));
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->exons[splitter[static_cast<int>(refFlat::txi)]] = std::stol(splitter[static_cast<int>(refFlat::exonsi)]);
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->exon_spans[splitter[static_cast<int>(refFlat::txi)]] = std::vector<std::pair<long, long>>();
-		for (int i = 0; i < ex_start.size(); i++) {
-		  data_[splitter[static_cast<int>(refFlat::chri)]].back()->exon_spans[splitter[static_cast<int>(refFlat::txi)]]
-			  .push_back(std::make_pair(std::stol(ex_start[i]), std::stol(ex_end[i])));
+                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->positions[splitter[static_cast<int>(refFlat::txi)]] =
+                          std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::starti))),
+                                         std::stol(splitter.str(static_cast<int>(refFlat::endi))));
+                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->cds[splitter[static_cast<int>(refFlat::txi)]] =
+                          std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::cds_starti))),
+                                         std::stol(splitter.str(static_cast<int>(refFlat::cds_endi))));
+                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->exons[splitter[static_cast<int>(refFlat::txi)]] =
+                      std::stol(splitter.str(static_cast<int>(refFlat::exonsi)));
+                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->exon_spans[splitter[static_cast<int>(refFlat::txi)]] = std::vector<std::pair<long, long>>();
+                  for (int i = 0; i < ex_start.size(); i++) {
+                    data_[splitter[static_cast<int>(refFlat::chri)]].back()->exon_spans[splitter[static_cast<int>(refFlat::txi)]]
+                            .push_back(std::make_pair(std::stol(ex_start.str(i)), std::stol(ex_end.str(i))));
 		}
 	  } catch(std::invalid_argument &e) {
 	    std::cerr << e.what() << std::endl;
@@ -87,17 +90,17 @@ void Reference::parse_refFlat(std::istream &ifs) {
 		gene_map_[splitter[static_cast<int>(refFlat::genei)]]->transcript.push_back(splitter[static_cast<int>(refFlat::txi)]);
 	  }
 	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->positions.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-		gene_map_[splitter[static_cast<int>(refFlat::genei)]]->positions[splitter[static_cast<int>(refFlat::txi)]] = std::make_pair(std::stol(splitter[static_cast<int>(refFlat::starti)]), std::stol(splitter[static_cast<int>(refFlat::endi)]));
+                  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->positions[splitter[static_cast<int>(refFlat::txi)]] = std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::starti))), std::stol(splitter.str(static_cast<int>(refFlat::endi))));
 	  }
 	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->cds.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-		gene_map_[splitter[static_cast<int>(refFlat::genei)]]->cds[splitter[static_cast<int>(refFlat::txi)]] = std::make_pair(std::stol(splitter[static_cast<int>(refFlat::cds_starti)]), std::stol(splitter[static_cast<int>(refFlat::cds_endi)]));
+                  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->cds[splitter[static_cast<int>(refFlat::txi)]] = std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::cds_starti))), std::stol(splitter.str(static_cast<int>(refFlat::cds_endi))));
 	  }
 	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exons.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-		gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exons[splitter[static_cast<int>(refFlat::txi)]] = std::stol(splitter[static_cast<int>(refFlat::exonsi)]);
+                  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exons[splitter[static_cast<int>(refFlat::txi)]] = std::stol(splitter.str(static_cast<int>(refFlat::exonsi)));
 	  }
 	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exon_spans.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
 		for (int i = 0; i < ex_start.size(); i++) {
-		  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exon_spans[splitter[static_cast<int>(refFlat::txi)]].push_back(std::make_pair(std::stol(ex_start[i]), std::stol(ex_end[i])));
+                    gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exon_spans[splitter[static_cast<int>(refFlat::txi)]].push_back(std::make_pair(std::stol(ex_start.str(i)), std::stol(ex_end.str(i))));
 		}
 	  }
 	}

--- a/utility/filevalidator.cpp
+++ b/utility/filevalidator.cpp
@@ -25,8 +25,8 @@ void FileValidator::validate_matrix_line(RJBUtil::Splitter<std::string> &line,
                             lineno);
     throw(std::runtime_error(msg.c_str()));
   }
-  if (!matrix_variant_types.contains(line[static_cast<int>(Indices::type)])
-  ) {
+  if (!matrix_variant_types.contains(
+          line.str(static_cast<int>(Indices::type)))) {
     const std::string msg = build_error_message(
         "ERROR: Matrix Line Validation -- Variant type incorrect. Must be one "
         "of {SNV, insertion, deletion, SPDA, complex_substitution}.",
@@ -88,7 +88,7 @@ void FileValidator::validate_weight_line(RJBUtil::Splitter<std::string> &line,
                             lineno);
     throw(std::runtime_error(msg.c_str()));
   }
-  if (!matrix_variant_types.contains(line[weight_type_index])) {
+  if (!matrix_variant_types.contains(line.str(weight_type_index))) {
     const std::string msg = build_error_message(
         "ERROR: Weight Line Validation -- Variant type "
         "incorrect. Must be one of {SNV, insertion, deletion, "
@@ -97,7 +97,7 @@ void FileValidator::validate_weight_line(RJBUtil::Splitter<std::string> &line,
     throw(std::runtime_error(msg.c_str()));
   }
   try {
-    std::stod(line.back());
+    std::stod(line.str(line.size() - 1));
   } catch (std::exception &e) {
     const std::string msg =
         build_error_message("ERROR: Weight Line Validation -- Non-numeric "

--- a/utility/jobdispatcher.hpp
+++ b/utility/jobdispatcher.hpp
@@ -342,15 +342,15 @@ private:
       if (split[static_cast<int>(Indices::gene)] == gene_) {
         add_line(current, line, split);
       } else {
-        if (previous_genes.contains(split[static_cast<int>(Indices::gene)])) {
-              throw std::runtime_error(
-              "Gene list must be sorted by gene name. Gene " +
-              split[static_cast<int>(Indices::gene)] +
-              " appears again on line " +
-              std::to_string(lineno) + " of the gene stream. " +
-              "Please sort the gene stream by gene name and transcript.");
+        auto gene_token = split.str(static_cast<int>(Indices::gene));
+        if (previous_genes.contains(gene_token)) {
+          throw std::runtime_error(
+              "Gene list must be sorted by gene name. Gene " + gene_token +
+              " appears again on line " + std::to_string(lineno) +
+              " of the gene stream. Please sort the gene stream by gene name "
+              "and transcript.");
         } else {
-              previous_genes.insert(split[static_cast<int>(Indices::gene)]);
+          previous_genes.insert(gene_token);
         }
         // Have we read a gene yet?
         if (!gene_.empty()) {
@@ -437,7 +437,8 @@ private:
             if (!gene_data.is_skippable())
               multiple_dispatch(gene_data);
 
-            auto fit = find_gene(split[static_cast<int>(Indices::gene)]);
+            auto gene_name = split.str(static_cast<int>(Indices::gene));
+            auto fit = find_gene(gene_name);
             if (fit != gene_list_.cend()) {
               // Next gene is in list
               split = RJBUtil::Splitter<std::string>(line, "\t");
@@ -455,7 +456,8 @@ private:
           }
         } else {
           // Skip until we find the first gene in our list.
-          auto fit = find_gene(split[static_cast<int>(Indices::gene)]);
+          auto gene_name = split.str(static_cast<int>(Indices::gene));
+          auto fit = find_gene(gene_name);
           if (fit == gene_list_.cend()) {
             continue;
           } else {
@@ -591,11 +593,11 @@ private:
         // Variant not masked
         ss << line << "\n";
         // Track number of variants in each transcript
-        if (nvariants_.find(split[static_cast<int>(Indices::transcript)]) ==
-            nvariants_.end()) {
-          nvariants_[split[static_cast<int>(Indices::transcript)]] = 1;
+        auto transcript = split.str(static_cast<int>(Indices::transcript));
+        if (nvariants_.find(transcript) == nvariants_.end()) {
+          nvariants_[transcript] = 1;
         } else {
-          nvariants_[split[static_cast<int>(Indices::transcript)]]++;
+          nvariants_[transcript]++;
         }
       }
     } else {
@@ -603,11 +605,11 @@ private:
         // Variant not masked
         ss << line << "\n";
         // Track number of variants in each transcript
-        if (nvariants_.find(split[static_cast<int>(Indices::transcript)]) ==
-            nvariants_.end()) {
-          nvariants_[split[static_cast<int>(Indices::transcript)]] = 1;
+        auto transcript = split.str(static_cast<int>(Indices::transcript));
+        if (nvariants_.find(transcript) == nvariants_.end()) {
+          nvariants_[transcript] = 1;
         } else {
-          nvariants_[split[static_cast<int>(Indices::transcript)]]++;
+          nvariants_[transcript]++;
         }
       }
     }

--- a/utility/reporter.cpp
+++ b/utility/reporter.cpp
@@ -617,21 +617,26 @@ auto Reporter::sort_simple(const TaskParams &tp) -> void {
     RJBUtil::Splitter<std::string> emp_ci_splitter(splitter[4], ",");
     RJBUtil::Splitter<std::string> emp_midci_splitter(splitter[6], ",");
 
-      ResultLine rs =
-          ResultLine{splitter[0], splitter[1], std::stold(splitter[2]),
-                     // std::stod(splitter[3]),
-                     std::stod(splitter[3]),
-                     std::make_pair(std::stod(emp_ci_splitter[0]),
-                                    std::stod(emp_ci_splitter[1])),
-                     std::stod(splitter[5]),
-                     std::make_pair(std::stod(emp_midci_splitter[0]),
-                                    std::stod(emp_midci_splitter[1])),
-                     std::stod(splitter[7]), std::stod(splitter[8]),
-                     std::stoul(splitter[9]), std::stoul(splitter[10]),
-                     std::stod(splitter[11]), std::stoul(splitter[12])};
+      ResultLine rs = ResultLine{
+          splitter.str(0),
+          splitter.str(1),
+          std::stold(splitter.str(2)),
+          // std::stod(splitter[3]),
+          std::stod(splitter.str(3)),
+          std::make_pair(std::stod(emp_ci_splitter.str(0)),
+                         std::stod(emp_ci_splitter.str(1))),
+          std::stod(splitter.str(5)),
+          std::make_pair(std::stod(emp_midci_splitter.str(0)),
+                         std::stod(emp_midci_splitter.str(1))),
+          std::stod(splitter.str(7)),
+          std::stod(splitter.str(8)),
+          std::stoul(splitter.str(9)),
+          std::stoul(splitter.str(10)),
+          std::stod(splitter.str(11)),
+          std::stoul(splitter.str(12))};
 
       for (int i = 13; i < splitter.size(); i++) {
-        rs.stats.push_back(splitter[i]);
+        rs.stats.push_back(splitter.str(i));
       }
       results.push_back(rs);
     // catch (std::exception &e) {

--- a/utility/split.hpp
+++ b/utility/split.hpp
@@ -103,6 +103,12 @@ public:
 
   view_type &at(int_type i) { return tokens_.at(i); }
 
+  string_type str(int_type i) const { return string_type(tokens_[i]); }
+
+  string_type at_str(int_type i) const { return string_type(tokens_.at(i)); }
+
+  static string_type str(view_type v) { return string_type(v); }
+
 private:
   /**
    * @brief A split member function to simplify multiple constructors should be


### PR DESCRIPTION
## Summary
- extend `Splitter` with helpers that return `std::string` tokens on demand
- use new helpers when parsing numeric options such as beta weights, covariates, weights and VCF utilities
- update reporters and validators to request strings before calling `std::sto*`
- ensure set lookups and file checks receive `std::string` arguments instead of `std::string_view`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: mach-o/dyld.h missing during test compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68bef46c8c6083208895f239a98c79df