### PR TITLE
Raise CMake minimum to 3.15 and update project declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.0)
-project(CAPER C CXX)
+cmake_minimum_required(VERSION 3.15)
+project(CAPER VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/tools/matrix_indexer/CMakeLists.txt
+++ b/tools/matrix_indexer/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-project(Permute_Associate C CXX)
+cmake_minimum_required(VERSION 3.15)
+project(matrix_indexer VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/tools/vcf2matrix/CMakeLists.txt
+++ b/tools/vcf2matrix/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-project(Permute_Associate C CXX)
+cmake_minimum_required(VERSION 3.15)
+project(vcf2matrix VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 


### PR DESCRIPTION
## Summary
- require CMake 3.15 in root and tool projects
- switch project declarations to explicit C++ language and add version 1.0

## Testing
- `cmake --version`
- `cmake -S . -B build` *(fails: Could NOT find Armadillo)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01d32860832093062d69d2fc4458