### PR TITLE
Remove unused CMAKE_MODULE_PATH setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,6 @@ message(${CMAKE_CXX_FLAGS_RELEASE}) # print "-O3 -DNDEBUG"
 #
 # set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} -Og")
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-
 find_package(Armadillo 8.6 REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost 1.66.0 COMPONENTS program_options iostreams REQUIRED)


### PR DESCRIPTION
## Summary
- remove unused addition to CMAKE_MODULE_PATH

## Testing
- `cmake -S . -B build`


------
https://chatgpt.com/codex/tasks/task_e_68bf02e96edc8320b76c01a27d03303f