### PR TITLE
Use absolute gradient for convergence in logistic regression

### DIFF
--- a/statistics/logistic_regression.cpp
+++ b/statistics/logistic_regression.cpp
@@ -61,7 +61,7 @@ auto LogisticRegression::gradient_descent(arma::mat &Xmat, arma::colvec &Yvec) -
 
 
     iterations++;
-  } while(iterations < max_iter && arma::any(grad > tol));
+  } while(iterations < max_iter && arma::any(arma::abs(grad) > tol));
   return t;
 }
 


### PR DESCRIPTION
## Summary
- Ensure logistic regression gradient descent termination uses absolute gradient magnitudes

## Testing
- `cmake --build . --target catch_test -j2`
- `./catch_test` *(fails: REQUIRE( skat == Approx(0.750000) ))*


------
https://chatgpt.com/codex/tasks/task_e_68c03dfe06288320ae84a6b6609ce4d4