### PR TITLE
Refactor tool builds to modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ find_package(Threads REQUIRED)
 find_package(Boost 1.66.0 COMPONENTS program_options iostreams REQUIRED)
 find_package(ZLIB REQUIRED)
 
+add_library(caper_utils STATIC utility/filesystem.cpp)
+target_include_directories(caper_utils PUBLIC
+        "${CMAKE_CURRENT_LIST_DIR}")
+target_link_libraries(caper_utils PUBLIC Boost::iostreams)
+
 if(NOT TARGET Armadillo::armadillo)
     add_library(Armadillo::armadillo INTERFACE IMPORTED)
     set_target_properties(Armadillo::armadillo PROPERTIES

--- a/tools/matrix_indexer/CMakeLists.txt
+++ b/tools/matrix_indexer/CMakeLists.txt
@@ -1,18 +1,22 @@
 cmake_minimum_required(VERSION 3.15)
 project(matrix_indexer VERSION 1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Boost 1.66.0 COMPONENTS program_options iostreams REQUIRED)
-
-include_directories(${Boost_INCLUDE_DIRS})
-
 add_executable(matrix_indexer matrix_indexer.cpp)
 
-target_link_libraries(matrix_indexer ${Boost_LIBRARIES})
+target_include_directories(matrix_indexer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(matrix_indexer PRIVATE
+    Boost::program_options
+    Boost::iostreams)
 
 target_compile_options(matrix_indexer PRIVATE
-        "$<$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>:$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-march=native>>"
-        "$<$<AND:$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>,$<CXX_COMPILER_ID:GNU>>:-fno-openmp>")
+    "$<$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>:$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-march=native>>"
+    "$<$<AND:$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>,$<CXX_COMPILER_ID:GNU>>:-fno-openmp>")
+
+install(TARGETS matrix_indexer RUNTIME DESTINATION bin)
+

--- a/tools/vcf2matrix/CMakeLists.txt
+++ b/tools/vcf2matrix/CMakeLists.txt
@@ -1,19 +1,26 @@
 cmake_minimum_required(VERSION 3.15)
 project(vcf2matrix VERSION 1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Boost 1.66.0 COMPONENTS program_options iostreams REQUIRED)
-
-include_directories(${Boost_INCLUDE_DIRS})
-
 add_executable(vcf2matrix
-               vcf2matrix.cpp reference.cpp reference.hpp ../../utility/filesystem.cpp ../../utility/filesystem.hpp parser.cpp parser.hpp ../../utility/jointhreads.hpp)
+    vcf2matrix.cpp
+    parser.cpp
+    reference.cpp)
 
-target_link_libraries(vcf2matrix ${Boost_LIBRARIES})
+target_include_directories(vcf2matrix PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(vcf2matrix PRIVATE
+    caper_utils
+    Boost::program_options
+    Boost::iostreams)
 
 target_compile_options(vcf2matrix PRIVATE
-        "$<$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>:$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-march=native>>"
-        "$<$<AND:$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>,$<CXX_COMPILER_ID:GNU>>:-fno-openmp>")
+    "$<$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>:$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-march=native>>"
+    "$<$<AND:$<BOOL:${ENABLE_NATIVE_OPTIMIZATIONS}>,$<CXX_COMPILER_ID:GNU>>:-fno-openmp>")
+
+install(TARGETS vcf2matrix RUNTIME DESTINATION bin)
+

--- a/tools/vcf2matrix/parser.cpp
+++ b/tools/vcf2matrix/parser.cpp
@@ -7,8 +7,8 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <sstream>
 #include "parser.hpp"
-#include "../../utility/filesystem.hpp"
-#include "../../utility/split.hpp"
+#include "utility/filesystem.hpp"
+#include "utility/split.hpp"
 
 Parser::Parser(const std::string &path, const std::string &outpath, Reference ref)
 	: ref_(std::move(ref)) {
@@ -53,8 +53,9 @@ void Parser::parse(std::istream &is, std::ostream &os) { // Parse VCF
 	  continue;
 	} else if (boost::starts_with(line, "#C")) {
 	  // Handle samples
-	  RJBUtil::Splitter<std::string> splitter(line, " \t");
-	  std::copy(splitter.begin() + 9, splitter.end(), std::back_inserter(header));
+          RJBUtil::Splitter<std::string> splitter(line, " \t");
+          std::transform(splitter.begin() + 9, splitter.end(), std::back_inserter(header),
+                         [](auto v) { return RJBUtil::Splitter<std::string>::str(v); });
 
 	  // Output header
 	  os << header[0];
@@ -74,7 +75,7 @@ void Parser::parse(std::istream &is, std::ostream &os) { // Parse VCF
 
 	cull(chr, pos, os); // Output completed genes.
 
-	Type type = variant_classifier(splitter[3], splitter[4]);
+        Type type = variant_classifier(splitter.str(3), splitter.str(4));
 
 	std::stringstream location_stream;
 

--- a/tools/vcf2matrix/reference.cpp
+++ b/tools/vcf2matrix/reference.cpp
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include "reference.hpp"
 
-#include "../../utility/filesystem.hpp"
-#include "../../utility/split.hpp"
+#include "utility/filesystem.hpp"
+#include "utility/split.hpp"
 
 Reference::Reference(const std::string &path) {
   std::ifstream ifs;
@@ -31,83 +31,88 @@ void Reference::parse_refFlat(std::istream &ifs) {
   std::string line;
 
   while (std::getline(ifs, line)) {
-	RJBUtil::Splitter<std::string> splitter(line, " \t");
-	// Skip ill-formed lines.
-	if (splitter.size() < 11) {
-	  continue;
-	}
+        RJBUtil::Splitter<std::string> splitter(line, " \t");
+        // Skip ill-formed lines.
+        if (splitter.size() < 11) {
+          continue;
+        }
 
-	RJBUtil::Splitter<std::string> ex_start(splitter[static_cast<int>(refFlat::exon_starti)], ",");
-	RJBUtil::Splitter<std::string> ex_end(splitter[static_cast<int>(refFlat::exon_endi)], ",");
+        RJBUtil::Splitter<std::string> ex_start(splitter[static_cast<int>(refFlat::exon_starti)], ",");
+        RJBUtil::Splitter<std::string> ex_end(splitter[static_cast<int>(refFlat::exon_endi)], ",");
 
-	if (ex_start.size() != ex_end.size()) {
-	  throw (std::runtime_error("Mismatched exon start and end positions."));
-	}
+        if (ex_start.size() != ex_end.size()) {
+          throw (std::runtime_error("Mismatched exon start and end positions."));
+        }
 
-	// If gene hasn't been read yet.
-	if (gene_map_.count(splitter[static_cast<int>(refFlat::genei)]) <= 0) {
-	  if (data_.count(splitter[static_cast<int>(refFlat::chri)]) == 0) {
-		data_[splitter[static_cast<int>(refFlat::chri)]] = std::vector<std::shared_ptr<Gene>>();
-	  }
-	  data_[splitter[static_cast<int>(refFlat::chri)]].push_back(std::make_shared<Gene>());
-	  gene_map_[splitter[static_cast<int>(refFlat::genei)]] = data_[splitter[static_cast<int>(refFlat::chri)]].back();
+        std::string gene = splitter.str(static_cast<int>(refFlat::genei));
+        std::string chr = splitter.str(static_cast<int>(refFlat::chri));
+        std::string tx = splitter.str(static_cast<int>(refFlat::txi));
+        std::string strand = splitter.str(static_cast<int>(refFlat::strandi));
 
-	  // Update fields
-	  try {
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->gene_name = splitter[static_cast<int>(refFlat::genei)];
-		// Checking if a transcript already exists so as to avoid duplicates.
-		if (std::find(data_[splitter[static_cast<int>(refFlat::chri)]].back()->transcript.begin(), data_[splitter[static_cast<int>(refFlat::chri)]].back()->transcript.end(), splitter[static_cast<int>(refFlat::txi)]) == data_[splitter[static_cast<int>(refFlat::chri)]].back()->transcript.end()) {
-		  data_[splitter[static_cast<int>(refFlat::chri)]].back()->transcript.push_back(splitter[static_cast<int>(refFlat::txi)]);
-		}
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->chromosome = splitter[static_cast<int>(refFlat::chri)];
-		data_[splitter[static_cast<int>(refFlat::chri)]].back()->strand = splitter[static_cast<int>(refFlat::strandi)];
-                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->positions[splitter[static_cast<int>(refFlat::txi)]] =
+        // If gene hasn't been read yet.
+        if (gene_map_.count(gene) <= 0) {
+          if (data_.count(chr) == 0) {
+                data_[chr] = std::vector<std::shared_ptr<Gene>>();
+          }
+          data_[chr].push_back(std::make_shared<Gene>());
+          gene_map_[gene] = data_[chr].back();
+
+          // Update fields
+          try {
+                data_[chr].back()->gene_name = gene;
+                // Checking if a transcript already exists so as to avoid duplicates.
+                if (std::find(data_[chr].back()->transcript.begin(), data_[chr].back()->transcript.end(), tx) == data_[chr].back()->transcript.end()) {
+                  data_[chr].back()->transcript.push_back(tx);
+                }
+                data_[chr].back()->chromosome = chr;
+                data_[chr].back()->strand = strand;
+                  data_[chr].back()->positions[tx] =
                           std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::starti))),
                                          std::stol(splitter.str(static_cast<int>(refFlat::endi))));
-                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->cds[splitter[static_cast<int>(refFlat::txi)]] =
+                  data_[chr].back()->cds[tx] =
                           std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::cds_starti))),
                                          std::stol(splitter.str(static_cast<int>(refFlat::cds_endi))));
-                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->exons[splitter[static_cast<int>(refFlat::txi)]] =
+                  data_[chr].back()->exons[tx] =
                       std::stol(splitter.str(static_cast<int>(refFlat::exonsi)));
-                  data_[splitter[static_cast<int>(refFlat::chri)]].back()->exon_spans[splitter[static_cast<int>(refFlat::txi)]] = std::vector<std::pair<long, long>>();
+                  data_[chr].back()->exon_spans[tx] = std::vector<std::pair<long, long>>();
                   for (int i = 0; i < ex_start.size(); i++) {
-                    data_[splitter[static_cast<int>(refFlat::chri)]].back()->exon_spans[splitter[static_cast<int>(refFlat::txi)]]
+                    data_[chr].back()->exon_spans[tx]
                             .push_back(std::make_pair(std::stol(ex_start.str(i)), std::stol(ex_end.str(i))));
-		}
-	  } catch(std::invalid_argument &e) {
-	    std::cerr << e.what() << std::endl;
-	    std::cerr << line << std::endl;
-	    std::exit(1);
-	  }
-	} else { // Add transcript to existing gene
-	  // Update fields
-	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->gene_name != splitter[static_cast<int>(refFlat::genei)]) {
-	    std::cerr << gene_map_[splitter[static_cast<int>(refFlat::genei)]]->gene_name << "\t" << splitter[static_cast<int>(refFlat::genei)] << std::endl;
-	    std::cerr << data_[splitter[static_cast<int>(refFlat::chri)]].size() << std::endl;
-		throw (std::runtime_error("Gene name mismatch."));
-	  }
-	  if (std::find(gene_map_[splitter[static_cast<int>(refFlat::genei)]]->transcript.begin(), gene_map_[splitter[static_cast<int>(refFlat::genei)]]->transcript.end(), splitter[static_cast<int>(refFlat::txi)]) == gene_map_[splitter[static_cast<int>(refFlat::genei)]]->transcript.end()) {
-		gene_map_[splitter[static_cast<int>(refFlat::genei)]]->transcript.push_back(splitter[static_cast<int>(refFlat::txi)]);
-	  }
-	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->positions.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-                  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->positions[splitter[static_cast<int>(refFlat::txi)]] = std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::starti))), std::stol(splitter.str(static_cast<int>(refFlat::endi))));
-	  }
-	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->cds.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-                  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->cds[splitter[static_cast<int>(refFlat::txi)]] = std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::cds_starti))), std::stol(splitter.str(static_cast<int>(refFlat::cds_endi))));
-	  }
-	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exons.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-                  gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exons[splitter[static_cast<int>(refFlat::txi)]] = std::stol(splitter.str(static_cast<int>(refFlat::exonsi)));
-	  }
-	  if (gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exon_spans.count(splitter[static_cast<int>(refFlat::txi)]) == 0) {
-		for (int i = 0; i < ex_start.size(); i++) {
-                    gene_map_[splitter[static_cast<int>(refFlat::genei)]]->exon_spans[splitter[static_cast<int>(refFlat::txi)]].push_back(std::make_pair(std::stol(ex_start.str(i)), std::stol(ex_end.str(i))));
-		}
-	  }
-	}
+                }
+          } catch(std::invalid_argument &e) {
+            std::cerr << e.what() << std::endl;
+            std::cerr << line << std::endl;
+            std::exit(1);
+          }
+        } else { // Add transcript to existing gene
+          // Update fields
+          if (gene_map_[gene]->gene_name != gene) {
+            std::cerr << gene_map_[gene]->gene_name << "\t" << gene << std::endl;
+            std::cerr << data_[chr].size() << std::endl;
+                throw (std::runtime_error("Gene name mismatch."));
+          }
+          if (std::find(gene_map_[gene]->transcript.begin(), gene_map_[gene]->transcript.end(), tx) == gene_map_[gene]->transcript.end()) {
+                gene_map_[gene]->transcript.push_back(tx);
+          }
+          if (gene_map_[gene]->positions.count(tx) == 0) {
+                  gene_map_[gene]->positions[tx] = std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::starti))), std::stol(splitter.str(static_cast<int>(refFlat::endi))));
+          }
+          if (gene_map_[gene]->cds.count(tx) == 0) {
+                  gene_map_[gene]->cds[tx] = std::make_pair(std::stol(splitter.str(static_cast<int>(refFlat::cds_starti))), std::stol(splitter.str(static_cast<int>(refFlat::cds_endi))));
+          }
+          if (gene_map_[gene]->exons.count(tx) == 0) {
+                  gene_map_[gene]->exons[tx] = std::stol(splitter.str(static_cast<int>(refFlat::exonsi)));
+          }
+          if (gene_map_[gene]->exon_spans.count(tx) == 0) {
+                for (int i = 0; i < ex_start.size(); i++) {
+                    gene_map_[gene]->exon_spans[tx].push_back(std::make_pair(std::stol(ex_start.str(i)), std::stol(ex_end.str(i))));
+                }
+          }
+        }
   }
   // Sort data_
   for (const auto &c : chromosomes) {
-	std::sort(data_[c].begin(), data_[c].end(), [](auto &lhs, auto &rhs){ return (*lhs) < (*rhs); });
+        std::sort(data_[c].begin(), data_[c].end(), [](auto &lhs, auto &rhs){ return (*lhs) < (*rhs); });
   }
 }
 


### PR DESCRIPTION
## Summary
- add caper_utils library for shared utility code
- modernize vcf2matrix and matrix_indexer CMake targets
- clean up includes to use project utility paths
- resolve Reference parser build failure by converting string_view keys to std::string

## Testing
- `cmake -S . -B build`
- `cmake --build build --target vcf2matrix`
- `cmake --build build --target matrix_indexer`


------
https://chatgpt.com/codex/tasks/task_e_68c03c5da9e083208124b21ac5e2aaab