### PR TITLE
Simplify variant masking in add_line

### DIFF
--- a/utility/jobdispatcher.hpp
+++ b/utility/jobdispatcher.hpp
@@ -570,34 +570,16 @@ private:
 
   void add_line(std::stringstream &ss, std::string &line,
                 RJBUtil::Splitter<std::string> &split) {
-    // Is variant masked?
+    // Build variant id once and check mask status
     std::stringstream varid;
-    varid << split[0] << "," << split[1] << "," << split[2] << "," << split[3] << "," << split[4];
-    if (split[static_cast<int>(Indices::end)] !=
-        split[static_cast<int>(Indices::start)]) {
-      if (!bed_.check_variant(varid.str())) {
-        // Variant not masked
-        ss << line << "\n";
-        // Track number of variants in each transcript
-        auto transcript = split.str(static_cast<int>(Indices::transcript));
-        if (nvariants_.find(transcript) == nvariants_.end()) {
-          nvariants_[transcript] = 1;
-        } else {
-          nvariants_[transcript]++;
-        }
-      }
-    } else {
-      if (!bed_.check_variant(varid.str())) {
-        // Variant not masked
-        ss << line << "\n";
-        // Track number of variants in each transcript
-        auto transcript = split.str(static_cast<int>(Indices::transcript));
-        if (nvariants_.find(transcript) == nvariants_.end()) {
-          nvariants_[transcript] = 1;
-        } else {
-          nvariants_[transcript]++;
-        }
-      }
+    varid << split[0] << "," << split[1] << "," << split[2] << "," << split[3]
+          << "," << split[4];
+    if (!bed_.check_variant(varid.str())) {
+      // Variant not masked
+      ss << line << "\n";
+      // Track number of variants in each transcript
+      auto transcript = split.str(static_cast<int>(Indices::transcript));
+      ++nvariants_[transcript];
     }
   }
 


### PR DESCRIPTION
## Summary
- refactor JobDispatcher::add_line to build variant ID once and check masking in a single branch

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 2`
- `./build/catch_test`

------
https://chatgpt.com/codex/tasks/task_e_68c041d7dca88320bad78051c1318ef4