### PR TITLE
Add JobDispatcher dispatch test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,5 +164,6 @@ target_link_libraries(power PRIVATE caper_core)
 # target_compile_definitions(caese PRIVATE MAXCOLORS=10000000)
 
 add_executable(catch_test
-        catch_test/test.cpp)
+        catch_test/test.cpp
+        catch_test/jobdispatcher_test.cpp)
 target_link_libraries(catch_test PRIVATE caper_core)

--- a/catch_test/jobdispatcher_test.cpp
+++ b/catch_test/jobdispatcher_test.cpp
@@ -1,0 +1,108 @@
+#include <catch2/catch.hpp>
+#include <fstream>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#define private public
+#include "../utility/jobdispatcher.hpp"
+#undef private
+#include "../data/filter.hpp"
+#include "../caper/capertask.hpp" // for Stage
+
+class DummyReporter {
+public:
+    std::vector<std::string> genes;
+    void set_ncases(arma::uword) {}
+    void set_ncontrols(arma::uword) {}
+    template <typename T>
+    void report(const T &, const TaskParams &) {}
+    template <typename T>
+    void vaast_sample_index_map(const T &) {}
+    void cleanup(const TaskParams &) {}
+};
+
+class DummyTask {
+public:
+    std::string gene;
+    DummyTask(Stage, Gene &g, std::shared_ptr<Covariates>, TaskParams &, std::vector<std::vector<int8_t>> &)
+        : gene(g.gene_name) {}
+    DummyTask(Stage, Gene &g, std::shared_ptr<Covariates>, TaskParams &, arma::uword, arma::uword, int, arma::uword, std::vector<std::vector<int8_t>> &)
+        : gene(g.gene_name) {}
+};
+
+class DummyOp {
+public:
+    bool done_;
+    DummyTask carvaTask;
+    std::shared_ptr<DummyReporter> reporter_;
+
+    DummyOp(DummyTask &t, std::shared_ptr<DummyReporter> reporter, double, bool)
+        : done_(true), carvaTask(t), reporter_(std::move(reporter)) {
+        reporter_->genes.push_back(carvaTask.gene);
+    }
+    DummyOp(DummyTask &&t, std::shared_ptr<DummyReporter> reporter, double, bool)
+        : done_(true), carvaTask(std::move(t)), reporter_(std::move(reporter)) {
+        reporter_->genes.push_back(carvaTask.gene);
+    }
+    void run() {}
+    void finish() {}
+};
+
+TEST_CASE("JobDispatcher dispatches tasks for each gene") {
+    namespace fs = std::filesystem;
+    auto tmp = fs::temp_directory_path();
+
+    auto ped_path = tmp / "jd_ped.ped";
+    std::ofstream ped(ped_path);
+    ped << "#FID\tIID\tFather\tMother\tSex\tPhenotype\n";
+    ped << "control1\tcontrol1\t0\t0\t0\t1\n";
+    ped << "control2\tcontrol2\t0\t0\t0\t1\n";
+    ped << "case1\tcase1\t0\t0\t0\t2\n";
+    ped << "case2\tcase2\t0\t0\t0\t2\n";
+    ped.close();
+
+    auto input_path = tmp / "jd_input.tsv";
+    std::ofstream input(input_path);
+    input << "Chr\tStart\tEnd\tRef\tAlt\tType\tGenes\tTranscripts\tRegion\tFunction\tAnnotation(c.change:p.change)\tcase1\tcase2\tcontrol1\tcontrol2\n";
+    input.close();
+
+    TaskParams tp{};
+    tp.covariates_path.clear();
+    tp.ped_path = ped_path.string();
+    tp.input_path = input_path.string();
+    tp.whitelist_path = (fs::path(__FILE__).parent_path().parent_path() / "filter" / "filter_whitelist.csv").string();
+    tp.nthreads = 2;
+    tp.nperm = 0;
+    tp.max_perms = 0; // prevent constructor from auto-dispatching
+    tp.mac = std::numeric_limits<arma::uword>::max();
+    tp.maf = 1.0;
+    tp.min_variant_count = 0;
+    tp.min_minor_allele_count = 0;
+    tp.no_weights = true;
+    tp.nocovadj = true;
+    tp.optimizer = "irls";
+    tp.method = "BURDEN";
+
+    auto reporter = std::make_shared<DummyReporter>();
+    JobDispatcher<DummyOp, DummyTask, DummyReporter> jd(tp, reporter);
+
+    // JobDispatcher frees its covariates after construction; reinitialize for manual dispatch
+    jd.cov_ = std::make_shared<Covariates>(tp);
+    jd.cov_->sort_covariates(jd.header_);
+
+    std::stringstream ss;
+    ss << "chr1\t1\t1\tA\tG\tSNV\tGene1\tTranscript1\tcoding\tnonsynonymous SNV\t.\t0101\n";
+    ss << "chr1\t2\t2\tT\tC\tSNV\tGene2\tTranscript1\tcoding\tnonsynonymous SNV\t.\t0101\n";
+
+    Filter filter(tp.whitelist_path);
+    jd.all_gene_dispatcher(ss, filter);
+
+    REQUIRE(jd.tq_.size() == 2);
+    REQUIRE(reporter->genes.size() == 2);
+    REQUIRE(reporter->genes[0] == "Gene1");
+    REQUIRE(reporter->genes[1] == "Gene2");
+}
+

--- a/link/binomial.cpp
+++ b/link/binomial.cpp
@@ -88,7 +88,7 @@ arma::vec Binomial::linkinv(const arma::mat &X,
   case Binomial::LinkID::Probit:
     return arma::normcdf(X * beta);
   case Binomial::LinkID::cloglog: {
-    arma::vec ret(beta.n_elem);
+    arma::vec ret(X.n_rows);
     auto vit = ret.begin();
     for (auto &v : arma::vec(X * beta)) {
       *vit = -std::expm1(-std::exp(v));
@@ -99,7 +99,7 @@ arma::vec Binomial::linkinv(const arma::mat &X,
     return ret;
   }
   case Binomial::LinkID::Cauchit: {
-    arma::vec ret(beta.n_elem);
+    arma::vec ret(X.n_rows);
     auto vit = ret.begin();
     boost::math::cauchy dist(0.0, 1.0);
     for (auto &v : arma::vec(X * beta)) {


### PR DESCRIPTION
## Summary
- configure JobDispatcher test to explicitly use IRLS optimizer and prevent auto-dispatch
- adjust binomial link to size inverse-link vectors by the number of rows
- reinitialize JobDispatcher's covariates in the test to avoid a null pointer during manual dispatch

## Testing
- `cmake --build build --target catch_test -j2`
- `./build/catch_test "JobDispatcher dispatches tasks for each gene"`


------
https://chatgpt.com/codex/tasks/task_e_68c054b966f48320a75aced3ab1600cb