### PR TITLE
test: check unsorted gene stream

### DIFF
--- a/catch_test/jobdispatcher_test.cpp
+++ b/catch_test/jobdispatcher_test.cpp
@@ -106,3 +106,56 @@ TEST_CASE("JobDispatcher dispatches tasks for each gene") {
     REQUIRE(reporter->genes[1] == "Gene2");
 }
 
+TEST_CASE("JobDispatcher throws when genes are not sorted") {
+    namespace fs = std::filesystem;
+    auto tmp = fs::temp_directory_path();
+
+    auto ped_path = tmp / "jd_ped.ped";
+    std::ofstream ped(ped_path);
+    ped << "#FID\tIID\tFather\tMother\tSex\tPhenotype\n";
+    ped << "control1\tcontrol1\t0\t0\t0\t1\n";
+    ped << "control2\tcontrol2\t0\t0\t0\t1\n";
+    ped << "case1\tcase1\t0\t0\t0\t2\n";
+    ped << "case2\tcase2\t0\t0\t0\t2\n";
+    ped.close();
+
+    auto input_path = tmp / "jd_input.tsv";
+    std::ofstream input(input_path);
+    input << "Chr\tStart\tEnd\tRef\tAlt\tType\tGenes\tTranscripts\tRegion\tFunction\tAnnotation(c.change:p.change)\tcase1\tcase2\tcontrol1\tcontrol2\n";
+    input.close();
+
+    TaskParams tp{};
+    tp.covariates_path.clear();
+    tp.ped_path = ped_path.string();
+    tp.input_path = input_path.string();
+    tp.whitelist_path = (fs::path(__FILE__).parent_path().parent_path() / "filter" / "filter_whitelist.csv").string();
+    tp.nthreads = 2;
+    tp.nperm = 0;
+    tp.max_perms = 0; // prevent constructor from auto-dispatching
+    tp.mac = std::numeric_limits<arma::uword>::max();
+    tp.maf = 1.0;
+    tp.min_variant_count = 0;
+    tp.min_minor_allele_count = 0;
+    tp.no_weights = true;
+    tp.nocovadj = true;
+    tp.optimizer = "irls";
+    tp.method = "BURDEN";
+
+    auto reporter = std::make_shared<DummyReporter>();
+    JobDispatcher<DummyOp, DummyTask, DummyReporter> jd(tp, reporter);
+
+    // JobDispatcher frees its covariates after construction; reinitialize for manual dispatch
+    jd.cov_ = std::make_shared<Covariates>(tp);
+    jd.cov_->sort_covariates(jd.header_);
+
+    std::stringstream ss;
+    ss << "chr1\t1\t1\tA\tG\tSNV\tGene1\tTranscript1\tcoding\tnonsynonymous SNV\t.\t0101\n";
+    ss << "chr1\t2\t2\tT\tC\tSNV\tGene2\tTranscript1\tcoding\tnonsynonymous SNV\t.\t0101\n";
+    ss << "chr1\t3\t3\tG\tA\tSNV\tGene1\tTranscript1\tcoding\tnonsynonymous SNV\t.\t0101\n";
+
+    Filter filter(tp.whitelist_path);
+    REQUIRE_THROWS_WITH(
+        jd.all_gene_dispatcher(ss, filter),
+        "Gene list must be sorted by gene name. Gene Gene1 appears again on line 2 of the gene stream. Please sort the gene stream by gene name and transcript.");
+}
+


### PR DESCRIPTION
## Summary
- add regression test for unsorted gene inputs to JobDispatcher

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 2`
- `./build/catch_test` *(fails: Data Construction & Methods SKAT, VAAST)*
- `./build/catch_test "JobDispatcher throws when genes are not sorted"`


------
https://chatgpt.com/codex/tasks/task_e_68c2f8887a2c8320b9ed18ad93d4ae3d