### PR TITLE
Keep external permutations accessible during external permutation tests

### DIFF
--- a/utility/jobdispatcher.hpp
+++ b/utility/jobdispatcher.hpp
@@ -304,7 +304,7 @@ public:
     tq_.join();
 
     // TODO: Free permutation memory
-    if (permutation_ptr_.use_count() == 1) {
+    if (!tp_.external && permutation_ptr_.use_count() == 1) {
       permutation_ptr_.reset();
     }
 


### PR DESCRIPTION
## Summary
- ensure JobDispatcher retains loaded permutations when using external permutation files
- update the external permutation test to leave max_perms unset so all external permutations are loaded

## Testing
- cmake -S . -B build
- cmake --build build --target catch_test
- ./build/catch_test

------
https://chatgpt.com/codex/tasks/task_e_68c98e090b0883208e2050cafabc4c9a