### PR TITLE
Optimize variant ID construction in job dispatcher

### DIFF
--- a/utility/jobdispatcher.hpp
+++ b/utility/jobdispatcher.hpp
@@ -570,10 +570,26 @@ private:
   void add_line(std::stringstream &ss, std::string &line,
                 RJBUtil::Splitter<std::string> &split) {
     // Build variant id once and check mask status
-    std::stringstream varid;
-    varid << split[0] << "," << split[1] << "," << split[2] << "," << split[3]
-          << "," << split[4];
-    if (!bed_.check_variant(varid.str())) {
+    const auto chrom = split[static_cast<int>(Indices::chrom)];
+    const auto start = split[static_cast<int>(Indices::start)];
+    const auto end = split[static_cast<int>(Indices::end)];
+    const auto ref = split[static_cast<int>(Indices::ref)];
+    const auto alt = split[static_cast<int>(Indices::alt)];
+
+    std::string variant_id;
+    variant_id.reserve(chrom.size() + start.size() + end.size() + ref.size() +
+                       alt.size() + 4);
+    variant_id.append(chrom.data(), chrom.size());
+    variant_id.push_back(',');
+    variant_id.append(start.data(), start.size());
+    variant_id.push_back(',');
+    variant_id.append(end.data(), end.size());
+    variant_id.push_back(',');
+    variant_id.append(ref.data(), ref.size());
+    variant_id.push_back(',');
+    variant_id.append(alt.data(), alt.size());
+
+    if (!bed_.check_variant(variant_id)) {
       // Variant not masked
       ss << line << "\n";
       // Track number of variants in each transcript


### PR DESCRIPTION
## Summary
- replace the stringstream-based variant id construction in `add_line` with an efficient `std::string`
- reserve the string capacity before appending and pass it directly to `bed_.check_variant`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9bcf810008320b84b45de24043850