### PR TITLE
Update SKAT kernel default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ VAAST Options:
     --alternate_grouping                  If enabled variants are grouped all together, otherwise by VAAST 2.0 type annotation.
 
 SKAT Options:
-    -k [ --kernel ] arg (=Linear)         Kernel for use with SKAT. One of: {Linear, wLinear}.
+    -k [ --kernel ] arg (=wLinear)        Kernel for use with SKAT. One of: {wLinear, Linear}.
     --qtl                                 Analyze a quantitative trait. Values are assumed to be finite floating point values.
     --beta_weights arg (=1,25)            Parameters for the beta distribution. Two values, comma separated corresponding to a,b.
     --saddlepoint                         Force the saddlepoint approximation. Useful for highly skewed case/control sample sizes.


### PR DESCRIPTION
## Summary
- update the SKAT options table in the README to show the default kernel as wLinear
- list the supported kernels in the order wLinear, Linear to reflect the default first

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceaf5f23b88320a802d1faa31ea3ab