### PR TITLE
Hoist case/control computations in generate_detail

### DIFF
--- a/data/gene.cpp
+++ b/data/gene.cpp
@@ -477,6 +477,8 @@ void Gene::generate_detail(Covariates &cov,
   std::stringstream detail;
 
   arma::vec Y = cov.get_original_phenotypes();
+  arma::uvec cases = arma::find(Y == 1);
+  arma::uvec controls = arma::find(Y == 0);
 
   std::unordered_map<std::string, std::vector<std::string>> pos_ts_map;
   std::unordered_map<std::string, double> pos_score_map;
@@ -497,10 +499,7 @@ void Gene::generate_detail(Covariates &cov,
   for (const auto &ts : transcripts) {
     arma::uword i = 0;
 
-    arma::uvec cases = arma::find(Y == 1);
-    arma::uvec controls = arma::find(Y == 0);
-
-    arma::sp_mat X(genotypes[ts]);
+    const arma::sp_mat &X = genotypes[ts];
 
     arma::rowvec maf = arma::rowvec(arma::mean(X) / 2.);
     // Ref/Alt Counts


### PR DESCRIPTION
## Summary
- hoist the case and control index lookups in `Gene::generate_detail` to reuse them across transcripts
- access each transcript's genotype sparse matrix by const reference instead of copying when generating detail output

## Testing
- cmake -S . -B build *(fails: Armadillo development files are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb5c47f4c832088e08de56d4814de