### PR TITLE
Use sparse column sums when computing MAC counts

### DIFF
--- a/caper/caperop.cpp
+++ b/caper/caperop.cpp
@@ -163,8 +163,10 @@ auto CAPEROp::op() -> void {
     res.update_ci();
 
     double n = 2. * gene.get_samples().size();
-    double nmac =
-        arma::accu(arma::sum(arma::mat(gene.genotypes[transcript]), 1) > 0);
+    const arma::sp_mat column_sums =
+        arma::sum(gene.genotypes[transcript], 1);
+    double nmac = static_cast<double>(
+        arma::find(column_sums.as_dense() > 0).n_elem);
     double nmaj = n - nmac;
 
     res.calc_exact_p(nmac, nmaj);


### PR DESCRIPTION
## Summary
- compute MAC counts using sparse column sums from the genotype matrix instead of casting to a dense matrix
- convert the sparse sums to dense form before applying the > 0 mask used to count carriers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb93796a08320800c2b26bc8ce6bd