### PR TITLE
Initialize epsilon permutation output buffers

### DIFF
--- a/caper/caperop.cpp
+++ b/caper/caperop.cpp
@@ -165,8 +165,7 @@ auto CAPEROp::op() -> void {
     double n = 2. * gene.get_samples().size();
     const arma::sp_mat column_sums =
         arma::sum(gene.genotypes[transcript], 1);
-    double nmac = static_cast<double>(
-        arma::find(column_sums.as_dense() > 0).n_elem);
+    double nmac = static_cast<double>(column_sums.n_nonzero);
     double nmaj = n - nmac;
 
     res.calc_exact_p(nmac, nmaj);

--- a/data/permutation.cpp
+++ b/data/permutation.cpp
@@ -142,6 +142,7 @@ Permute::epsilon_permutation(int nperm, arma::vec &odds, arma::uword ncases,
   arma::uword msize = std::accumulate(m.begin(), m.end(), 0);
   assert(msize == odds.n_rows);
 #endif
+  ret.assign(nperm, std::vector<int8_t>(odds.n_rows));
   for (int i = 0; i < nperm; i++) {
     std::vector<int32_t> tmp(bin_odds.size(), 0);
     sto.MultiFishersNCHyp(&tmp[0], &(m[0]), &(bin_odds[0]), ncases,

--- a/statistics/vaast.cpp
+++ b/statistics/vaast.cpp
@@ -177,8 +177,7 @@ double VAASTLogic::Score(const arma::sp_mat &X, const arma::vec &Y,
     arma::vec variant(n_case + n_control, arma::fill::zeros);
 
     if (collapse.n_elem > 0) {
-      variant =
-          arma::conv_to<arma::vec>::from(arma::sum(X.cols(collapse), 1));
+      variant = arma::sum(arma::mat(X.cols(collapse)), 1);
     }
     variant(arma::find(variant == 1)).fill(0); // Set all single hets to 0
     variant(arma::find(variant > 1))


### PR DESCRIPTION
## Summary
- reset the cached epsilon permutation result buffer to match the requested permutation and sample counts before filling it
- update Armadillo-dependent logic in VAAST scoring and CAPER exact-p calculations to use APIs still available in Armadillo 12

## Testing
- cmake --build build --target catch_test
- ./build/catch_test


------
https://chatgpt.com/codex/tasks/task_e_68d15b8ffc6c83208c08631926789d5d