### PR TITLE
Remove unused VT_Res data caches

### DIFF
--- a/statistics/vt.hpp
+++ b/statistics/vt.hpp
@@ -5,7 +5,10 @@
 #ifndef PERMUTE_ASSOCIATE_VT_HPP
 #define PERMUTE_ASSOCIATE_VT_HPP
 
-#include "../data/covariates.hpp"
+#include <armadillo>
+#include <map>
+#include <string>
+
 #include "../data/gene.hpp"
 
 class VT_Res {


### PR DESCRIPTION
## Summary
- drop the unused covariates include from `VT_Res` and add the required standard/Armadillo headers directly.

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d194283f948320addc7582190fd163