### PR TITLE
Add deterministic RNG tests for permutation helpers

### DIFF
--- a/catch_test/permutation_test.cpp
+++ b/catch_test/permutation_test.cpp
@@ -2,7 +2,9 @@
 
 #include <armadillo>
 
+#include <algorithm>
 #include <cstdint>
+#include <numeric>
 #include <vector>
 
 #include "../data/permutation.hpp"
@@ -50,4 +52,54 @@ TEST_CASE("Permute::build_bins groups odds according to epsilon") {
     double expected_average = arma::accu(odds_copy) / static_cast<double>(odds_copy.n_rows);
     REQUIRE(perm.bin_odds.front() == Approx(expected_average));
   }
+}
+
+TEST_CASE("Permute::unpack respects shuffle flag") {
+  Permute perm(12345);
+  const int successes = 3;
+  const int bin_size = 5;
+
+  SECTION("without shuffle produces leading ones followed by zeros") {
+    StochasticLib3 rng(777);
+    auto result = perm.unpack(successes, bin_size, false, rng);
+
+    std::vector<int8_t> expected{1, 1, 1, 0, 0};
+    REQUIRE(result == expected);
+    REQUIRE(std::accumulate(result.begin(), result.end(), 0) == successes);
+  }
+
+  SECTION("with shuffle retains counts and is deterministic with fixed seed") {
+    StochasticLib3 rng(777);
+    auto shuffled = perm.unpack(successes, bin_size, true, rng);
+
+    REQUIRE(shuffled.size() == bin_size);
+    REQUIRE(std::accumulate(shuffled.begin(), shuffled.end(), 0) == successes);
+
+    auto expected = shuffled;
+
+    StochasticLib3 rng_repeat(777);
+    auto reshuffled = perm.unpack(successes, bin_size, true, rng_repeat);
+
+    REQUIRE(reshuffled == expected);
+  }
+}
+
+TEST_CASE("Permute::fisher_yates matches manual shuffle with same seed") {
+  std::vector<int8_t> input{0, 1, 2, 3};
+  auto original = input;
+
+  StochasticLib3 rng(777);
+  Permute::fisher_yates(input, rng);
+
+  REQUIRE(std::is_permutation(input.begin(), input.end(), original.begin(),
+                              original.end()));
+
+  std::vector<int8_t> expected = original;
+  StochasticLib3 rng_repeat(777);
+  for (int i = static_cast<int>(expected.size()) - 1; i >= 1; --i) {
+    auto j = rng_repeat.IRandom(0, i);
+    std::swap(expected[i], expected[j]);
+  }
+
+  REQUIRE(input == expected);
 }


### PR DESCRIPTION
## Summary
- extend the permutation Catch2 suite with deterministic RNG seeding utilities
- verify `Permute::unpack` returns ordered output without shuffling and reproducible shuffles with the same seed
- check `Permute::fisher_yates` preserves the input permutation multiset and matches a manually reproduced shuffle

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/catch_test`


------
https://chatgpt.com/codex/tasks/task_e_68d2b66705cc8320afa0b6331b3f2645