### PR TITLE
Add GitHub Actions workflow to build caper and power

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            libarmadillo-dev \
+            libboost-iostreams-dev \
+            libboost-program-options-dev \
+            liblapack-dev \
+            libblas-dev \
+            zlib1g-dev
+
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build caper and power
+        run: cmake --build build --config Release --target caper power


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs build dependencies
- configure and build the caper and power targets on pushes and pull requests to main

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d813320e44832084471bec16798a10