### PR TITLE
Refactor method dispatch to function mapping

### DIFF
--- a/caper/caperop.cpp
+++ b/caper/caperop.cpp
@@ -62,7 +62,7 @@ auto CAPEROp::op() -> void {
                                 (1. - cov.get_original_phenotypes()));
       res.cont_ref =
           2 * arma::accu(1. - cov.get_original_phenotypes()) - res.cont_alt;
-      res.original = caperTask.methods.call(
+      res.original = caperTask.methods.evaluate(
           gene, cov, cov.get_original_phenotypes(), transcript, true);
       res.is_set = true;
     }
@@ -101,7 +101,7 @@ auto CAPEROp::op() -> void {
 #endif
 
       double perm_val =
-          caperTask.methods.call(gene, cov, phenotypes, transcript, false);
+          caperTask.methods.evaluate(gene, cov, phenotypes, transcript, false);
 
       res.permuted.push_back(perm_val);
 

--- a/data/gene.cpp
+++ b/data/gene.cpp
@@ -675,7 +675,7 @@ bool Gene::check_testability(const std::string &transcript, Covariates &cov,
   assert(arma::accu(extreme_phen) == ncase);
 
   Gene tmp = *this;
-  double score = methods.call(tmp, cov, extreme_phen, transcript, true);
+  double score = methods.evaluate(tmp, cov, extreme_phen, transcript, true);
 
   if (tp.method == "VAAST" || tp.method == "SKAT") {
     bool testable_variants =

--- a/statistics/methods.hpp
+++ b/statistics/methods.hpp
@@ -8,6 +8,7 @@
 #define ARMA_DONT_USE_WRAPPER
 
 #include <armadillo>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -27,8 +28,12 @@ public:
   Methods(const TaskParams &tp, const std::shared_ptr<Covariates> &cov);
   Methods(const TaskParams &tp, const Covariates &cov);
 
-  double call(Gene &gene, Covariates &cov, arma::vec &phenotypes,
-              const std::string &transcript, bool detail);
+  using MethodFn =
+      std::function<double(Gene &, Covariates &, arma::vec &,
+                           const std::string &, bool)>;
+
+  double evaluate(Gene &gene, Covariates &cov, arma::vec &phenotypes,
+                  const std::string &transcript, bool detail);
 
   std::string str();
 
@@ -66,7 +71,7 @@ public:
   static double WSS(Gene &gene, arma::vec &Y, const std::string &k);
 
 private:
-  const std::string method_;
+  MethodFn method_fn_;
 
   // SKAT support fields
   Kernel kernel_;
@@ -77,6 +82,7 @@ private:
   // Check weighting
   void check_weights(Gene &gene, const std::string &transcript, int a = 1,
                      int b = 25, bool no_weight = false);
+  void initialize_method_fn();
 
   // SKAT Null Model
   std::shared_ptr<SKATR_Null> obj_;


### PR DESCRIPTION
## Summary
- replace the string-based dispatch in `Methods` with a `MethodFn` alias and dedicated `evaluate` entry point
- initialize a one-time map from method names to bound lambdas when constructing `Methods`
- update `CAPEROp` and gene testability checks to call the new interface

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: missing Armadillo dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e31214f7748320883fed78a458180b